### PR TITLE
Create 아두이노-라즈베리파이 연동 테스트 코드.py

### DIFF
--- a/아두이노-라즈베리파이 연동 테스트 코드.py
+++ b/아두이노-라즈베리파이 연동 테스트 코드.py
@@ -1,0 +1,27 @@
+# 연결 테스트 코드
+# 아두이노: 파일 → 예제 → Firmata → StandFirmata 실행
+# 라즈베리파이: 아래 코드 실행
+# 아두이노의 기판 LED 깜빡임을 확인할 수 있는 테스트 코드입니다.
+
+#!/usr/bin/env python3
+#!pip install pyfirmata
+from pyfirmata import Arduino
+
+PIN = 13
+DELAY = 1
+board = None
+
+
+def Blink():
+    global board
+    #
+    if board is None:
+        board = Arduino('COM4')
+        print("Communication Successfully started")
+    while True:
+        board.digital[PIN].write(1) 
+        board.pass_time(DELAY) 
+        board.digital[PIN].write(0) 
+        board.pass_time(DELAY)
+
+Blink()


### PR DESCRIPTION
라즈베리파이와 아두이노를 연결한 후, 센서 부착 전 연결을 테스트 해볼 수 있는 코드입니다.
아두이노 기판의 내장 LED (13번)가 깜빡거리게 됩니다.